### PR TITLE
Possible fix for "iOS Safari: “Nominate another person” button is translucent"

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -256,3 +256,33 @@ a.is-loading .button-label {
   0%, 39%, 100% { opacity: 0; }
   40% { opacity: 1; }
 }
+
+ Dim element on hover by adding the dim class.
+
+*/
+.dim {
+  opacity: 1;
+  -webkit-transition: opacity .15s ease-in;
+  transition: opacity .15s ease-in;
+}
+
+@media screen and (min-width: 30em) {
+  .dim:hover, .dim:focus {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    opacity: .5;
+    -webkit-transition: opacity .15s ease-in;
+    transition: opacity .15s ease-in;
+  }
+}
+
+.dim:active {
+  -webkit-backface-visibility:
+  hidden; backface-visibility: hidden;
+  opacity: .8;
+  -webkit-transition: opacity .15s ease-out;
+  transition: opacity .15s ease-out;
+}
+
+/*
+


### PR DESCRIPTION
Wrapping the button hover in a media query so it only does it on bigger screens. Attempted fix for #50